### PR TITLE
v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2021-12-22
+
+### Added
+
+- The `Router` class is now PSR-3 compatible and builds upon the `Psr\Log` interfaces. The class uses the `LoggerAwareTrait` to instantiate a logger instance with `NullLogger`. See also [2: Add logging capabilities](https://github.com/Digital-Media/fhooe-router/issues/2).
+- Logging messages that inform users about added routes, route matches, a set 404 callback and an executed 404 callback.
+- Added a static `getBasePath()` method to retrieve the base path. This can be used in view templates to prepend the base path to URLs.
+
 ## [0.1.0] - 2021-12-16
+
 ### Added
 - Complete `Router` class with dynamic and static functionality.
 - Allowed setting routes for GET and POST protocols with patterns and invocable callbacks.
@@ -20,5 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added notes on Contributing.
 - Added this changelog.
 
-[Unreleased]: https://github.com/Digital-Media/fhooe-router/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/Digital-Media/fhooe-router/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Digital-Media/fhooe-router/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Digital-Media/fhooe-router/releases/tag/v0.1.0

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     ],
     "require": {
         "php": ">=7.4",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,59 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b73a2b8c1113d0e131dd39705cf681de",
-    "packages": [],
+    "content-hash": "bea66e6843fc19d1224400b22bd741fd",
+    "packages": [
+        {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "phpstan/phpstan",

--- a/src/Router.php
+++ b/src/Router.php
@@ -7,6 +7,8 @@ namespace Fhooe\Router;
 use Closure;
 use Fhooe\Router\Exception\HandlerNotSetException;
 use InvalidArgumentException;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\NullLogger;
 
 /**
  * A simple object-oriented Router for educational purposes.
@@ -21,6 +23,8 @@ use InvalidArgumentException;
  */
 class Router
 {
+    use LoggerAwareTrait;
+
     /**
      * @var array<string> The supported HTTP methods for this router.
      */
@@ -51,6 +55,7 @@ class Router
     {
         $this->routes = [];
         $this->noRouteCallback = null;
+        $this->logger = new NullLogger();
     }
 
     /**

--- a/src/Router.php
+++ b/src/Router.php
@@ -81,6 +81,7 @@ class Router
                 "pattern" => $pattern,
                 "callback" => $callback
             ];
+            $this->logger->info("Route added: " . $method . " " . $pattern);
         } else {
             throw new InvalidArgumentException("Method must be one of the following: " . implode("|", self::METHODS));
         }
@@ -113,6 +114,7 @@ class Router
     public function set404Callback(Closure $callback): void
     {
         $this->noRouteCallback = $callback;
+        $this->logger->info("404 callback set.");
     }
 
     /**
@@ -131,6 +133,7 @@ class Router
         http_response_code(404);
         if ($this->noRouteCallback) {
             ($this->noRouteCallback)();
+            $this->logger->info("No route match found. 404 callback executed.");
         } else {
             throw new HandlerNotSetException("404 Handler not set.");
         }
@@ -152,6 +155,9 @@ class Router
             if ($route["pattern"] === $uri) {
                 if (is_callable($route["callback"])) {
                     $route["callback"]();
+                    $this->logger->info(
+                        "Route match found: " . $route["method"] . " " . $route["pattern"] . ". Callback executed."
+                    );
                     return true;
                 }
             }

--- a/src/Router.php
+++ b/src/Router.php
@@ -228,4 +228,14 @@ class Router
 
         return $url;
     }
+
+    /**
+     * Returns the base path if the application is not in the server's document root. If no base path is set, an empty
+     * string is returned.
+     * @return string The base path without a trailing slash or an empty string if no base path is set.
+     */
+    public static function getBasePath(): string
+    {
+        return self::$basePath ?? "";
+    }
 }


### PR DESCRIPTION
Release v0.2.0

- The `Router` class is now PSR-3 compatible and builds upon the `Psr\Log` interfaces. The class uses the `LoggerAwareTrait` to instantiate a logger instance with `NullLogger`.
- Logging messages that inform users about added routes, route matches, a set 404 callback and an executed 404 callback.
- Added a static `getBasePath()` method to retrieve the base path. This can be used in view templates to prepend the base path to URLs.

This closes #2.